### PR TITLE
Add PowerShell script to create and activate a custom power plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Mega Collection of PowerShell Scripts
 | [close-thunderbird.ps1](scripts/close-thunderbird.ps1) | Closes Mozilla Thunderbird. [More »](docs/close-thunderbird.md)                     |
 | [close-vlc.ps1](scripts/close-vlc.ps1)               | Closes the VLC media player application. [More »](docs/close-vlc.md)                  |
 | [close-windows-terminal.ps1](scripts/close-windows-terminal.ps1) | Closes the Windows Terminal application. [More »](docs/close-windows-terminal.md)  |
+| [create-power-plan.ps1](scripts/create-power-plan.ps1) | creates a custom power plan based on the active one. [More »](docs/create-power-plan.md)  |
 | [enable-god-mode.ps1](scripts/enable-god-mode.ps1)   | Enables the god mode (adds a new icon to the desktop). [More »](docs/enable-god-mode.md) |
 | [install-chrome.ps1](scripts/install-chrome.ps1)     | Installs the Google Chrome browser. [Read more...](docs/install-chrome-browser.md)          |
 | [install-firefox.ps1](scripts/install-firefox.ps1)   | Installs the Firefox browser. [Read more...](docs/install-firefox.md)                       |

--- a/docs/create-power-plan.md
+++ b/docs/create-power-plan.md
@@ -11,7 +11,6 @@
 .EXAMPLE
 	PS> ./create-custom-power-plan.ps1
 
-
 .LINK
 	https://github.com/Arash-Seifi/PowerShell
 .NOTES
@@ -20,19 +19,25 @@
 
 
 try {
-    Add-Type -AssemblyName System.Speech
-    
-    $Synth = New-Object System.Speech.Synthesis.SpeechSynthesizer
+    # Step 1: Get the Active Power Plan GUID
+    $activeGuid = powercfg /getactivescheme | Select-String -Pattern "GUID" | ForEach-Object { $_.ToString().Split(' ')[3] }
+    Write-Output "Active Power Plan GUID: $activeGuid"
 
-    $Synth.GetInstalledVoices() | 
-        Select-Object -ExpandProperty VoiceInfo | 
-        Select-Object -Property Name, Culture, Gender, Age
-    
-    # Indicate success and exit with status 0
-    exit 0
+    # Step 2: Duplicate the Active Power Plan and capture the new GUID
+    $newGuid = powercfg -duplicatescheme $activeGuid | ForEach-Object { $_.ToString().Split(' ')[3] }
+    Write-Output "New Power Plan GUID: $newGuid"
+
+    # Step 3: Rename the New Power Plan
+    $customName = "My Custom Plan"
+    powercfg -changename $newGuid $customName
+
+    # Step 4: Set the New Power Plan as Active
+    powercfg -setactive $newGuid
+
+    # Output the new power plan GUID
+    Write-Output "New power plan created with GUID: $newGuid and set as active."
 } 
 catch {
     "⚠️ Error in line $($_.InvocationInfo.ScriptLineNumber): $($Error[0])"
-    
     exit 1
 }

--- a/docs/create-power-plan.md
+++ b/docs/create-power-plan.md
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+	Create and Set Custom Power Plan
+.DESCRIPTION
+	Creates a custom power plan based on the active power plan, renames it, and sets it as the active power plan.
+    This PowerShell script:
+    1. Retrieves the active power plan GUID.
+    2. Duplicates the active power plan.
+    3. Renames the new power plan to a custom name.
+    4. Sets the newly created power plan as the active plan.
+.EXAMPLE
+	PS> ./create-custom-power-plan.ps1
+
+
+.LINK
+	https://github.com/Arash-Seifi/PowerShell
+.NOTES
+	Author: Arash Seifi | License: CC0
+#>
+
+
+try {
+    Add-Type -AssemblyName System.Speech
+    
+    $Synth = New-Object System.Speech.Synthesis.SpeechSynthesizer
+
+    $Synth.GetInstalledVoices() | 
+        Select-Object -ExpandProperty VoiceInfo | 
+        Select-Object -Property Name, Culture, Gender, Age
+    
+    # Indicate success and exit with status 0
+    exit 0
+} 
+catch {
+    "⚠️ Error in line $($_.InvocationInfo.ScriptLineNumber): $($Error[0])"
+    
+    exit 1
+}

--- a/docs/create-power-plan.md
+++ b/docs/create-power-plan.md
@@ -1,23 +1,20 @@
-<#
-.SYNOPSIS
-	Create and Set Custom Power Plan
-.DESCRIPTION
-	Creates a custom power plan based on the active power plan, renames it, and sets it as the active power plan.
-    This PowerShell script:
-    1. Retrieves the active power plan GUID.
-    2. Duplicates the active power plan.
-    3. Renames the new power plan to a custom name.
-    4. Sets the newly created power plan as the active plan.
-.EXAMPLE
-	PS> ./create-custom-power-plan.ps1
+## SYNOPSIS
+Create and Set Custom Power Plan
+## DESCRIPTION
+Creates a custom power plan based on the active power plan, renames it, and sets it as the active power plan.
+This PowerShell script:
+1. Retrieves the active power plan GUID.
+2. Duplicates the active power plan.
+3. Renames the new power plan to a custom name.
+4. Sets the newly created power plan as the active plan.
+## EXAMPLE
+	PS> ./create-power-plan.ps1
 
-.LINK
-	https://github.com/Arash-Seifi/PowerShell
-.NOTES
-	Author: Arash Seifi | License: CC0
-#>
-
-
+## LINK
+https://github.com/Arash-Seifi/PowerShell
+## NOTES
+Author: Arash Seifi | License: CC0
+```
 try {
     # Step 1: Get the Active Power Plan GUID
     $activeGuid = powercfg /getactivescheme | Select-String -Pattern "GUID" | ForEach-Object { $_.ToString().Split(' ')[3] }
@@ -41,3 +38,4 @@ catch {
     "⚠️ Error in line $($_.InvocationInfo.ScriptLineNumber): $($Error[0])"
     exit 1
 }
+```

--- a/scripts/create-power-plan.ps1
+++ b/scripts/create-power-plan.ps1
@@ -1,0 +1,17 @@
+# Step 1: Get the Active Power Plan GUID
+$activeGuid = powercfg /getactivescheme | Select-String -Pattern "GUID" | ForEach-Object { $_.ToString().Split(' ')[3] }
+Write-Output "Active Power Plan GUID: $activeGuid"
+
+# Step 2: Duplicate the Active Power Plan and capture the new GUID
+$newGuid = powercfg -duplicatescheme $activeGuid | ForEach-Object { $_.ToString().Split(' ')[3] }
+Write-Output "New Power Plan GUID: $newGuid"
+
+# Step 3: Rename the New Power Plan
+$customName = "My Custom Plan"
+powercfg -changename $newGuid $customName
+
+# Step 4: Set the New Power Plan as Active
+powercfg -setactive $newGuid
+
+# Output the new power plan GUID
+Write-Output "New power plan created with GUID: $newGuid and set as active."


### PR DESCRIPTION
This script duplicates the active power plan, renames the new power plan, and sets it as the active plan. It automates the process of creating a custom power plan in Windows using ```powercfg``` commands.
Changes Made:
Added a PowerShell script that:
Retrieves the GUID of the active power plan.
Duplicates the active power plan and captures the new GUID.
Renames the new power plan to a user-defined name (in this case, "My Custom Plan").
Sets the new power plan as the active plan.
Usage:
Simply run the script, and it will create a new power plan based on the currently active one, rename it, and activate it.